### PR TITLE
Data Utils -> Structures

### DIFF
--- a/src/structures/album.ts
+++ b/src/structures/album.ts
@@ -1,4 +1,4 @@
-/** @module AlbumStruct Contains data structures for albums. */
+/** @module AlbumStructs Contains data structures for albums. */
 import { Prisma } from "@prisma/client"
 import { TrackCreateTemplate, trackCTToInput } from "./track"
 import { isBlankArray } from "../util/templateValidation"

--- a/src/structures/album.ts
+++ b/src/structures/album.ts
@@ -1,4 +1,4 @@
-/** @module AlbumDataUtils Contains data utilities for albums. */
+/** @module AlbumStruct Contains data structures for albums. */
 import { Prisma } from "@prisma/client"
 import { TrackCreateTemplate, trackCTToInput } from "./track"
 import { isBlankArray } from "../util/templateValidation"

--- a/src/structures/artist.ts
+++ b/src/structures/artist.ts
@@ -1,4 +1,4 @@
-/** @module ArtistStruct Contains data structures for artists. */
+/** @module ArtistStructs Contains data structures for artists. */
 import { Prisma, Availability } from "@prisma/client"
 import { ArtistMetadataCreateTemplate, artistMetadataCTToInput } from "./artistMetadata";
 import { RightCreateTemplate, rightCTToInput } from "./right";

--- a/src/structures/artist.ts
+++ b/src/structures/artist.ts
@@ -1,4 +1,4 @@
-/** @module ArtistDataUtils Contains data utilities for artists. */
+/** @module ArtistStruct Contains data structures for artists. */
 import { Prisma, Availability } from "@prisma/client"
 import { ArtistMetadataCreateTemplate, artistMetadataCTToInput } from "./artistMetadata";
 import { RightCreateTemplate, rightCTToInput } from "./right";

--- a/src/structures/artistMetadata.ts
+++ b/src/structures/artistMetadata.ts
@@ -1,4 +1,4 @@
-/** @module ArtistMetadataStruct Contains structures for artist metadatas. */
+/** @module ArtistMetadataStructs Contains structures for artist metadatas. */
 import { Prisma } from "@prisma/client"
 import { AlbumCreateTemplate, albumCTToInput } from "./album"
 import { isBlankArray, ensureNotBlankString, ensureNotBlankStringArray } from "../util/templateValidation"

--- a/src/structures/artistMetadata.ts
+++ b/src/structures/artistMetadata.ts
@@ -1,4 +1,4 @@
-/** @module ArtistMetadataDataUtils Contains data utilities for artist metadatas. */
+/** @module ArtistMetadataStruct Contains structures for artist metadatas. */
 import { Prisma } from "@prisma/client"
 import { AlbumCreateTemplate, albumCTToInput } from "./album"
 import { isBlankArray, ensureNotBlankString, ensureNotBlankStringArray } from "../util/templateValidation"

--- a/src/structures/musicLabel.ts
+++ b/src/structures/musicLabel.ts
@@ -1,4 +1,4 @@
-/** @module MusicLabelStruct Contains structures for music labels. */
+/** @module MusicLabelStructs Contains structures for music labels. */
 import { Prisma, Availability } from "@prisma/client"
 import { ArtistCreateTemplate, artistCTToInput } from "./artist";
 import { isBlankArray } from "../util/templateValidation";

--- a/src/structures/musicLabel.ts
+++ b/src/structures/musicLabel.ts
@@ -1,4 +1,4 @@
-/** @module MusicLabelDataUtils Contains data utilities for music labels. */
+/** @module MusicLabelStruct Contains structures for music labels. */
 import { Prisma, Availability } from "@prisma/client"
 import { ArtistCreateTemplate, artistCTToInput } from "./artist";
 import { isBlankArray } from "../util/templateValidation";

--- a/src/structures/right.ts
+++ b/src/structures/right.ts
@@ -1,4 +1,4 @@
-/** @module RightsDataUtils Contains structures for rights. */
+/** @module RightsStructs Contains structures for rights. */
 import { Prisma } from "@prisma/client"
 
 /** The create template for rights. */

--- a/src/structures/right.ts
+++ b/src/structures/right.ts
@@ -1,4 +1,4 @@
-/** @module RightsDataUtils Contains data utilities for rights. */
+/** @module RightsDataUtils Contains structures for rights. */
 import { Prisma } from "@prisma/client"
 
 /** The create template for rights. */

--- a/src/structures/track.ts
+++ b/src/structures/track.ts
@@ -1,4 +1,4 @@
-/** @module TrackDataUtils Contains structures for tracks. */
+/** @module TrackStructs Contains structures for tracks. */
 import { Prisma } from "@prisma/client"
 import { Availability } from "@prisma/client"
 import { ensureNotBlankString, ensureNotBlankStringArray } from "../util/templateValidation"

--- a/src/structures/track.ts
+++ b/src/structures/track.ts
@@ -1,4 +1,4 @@
-/** @module TrackDataUtils Contains data utilities for tracks. */
+/** @module TrackDataUtils Contains structures for tracks. */
 import { Prisma } from "@prisma/client"
 import { Availability } from "@prisma/client"
 import { ensureNotBlankString, ensureNotBlankStringArray } from "../util/templateValidation"


### PR DESCRIPTION
Follows up the change on renaming the folder from `"data_utils"` to `structures` by updating corresponding documentation.