### PR TITLE
Safe Name

### DIFF
--- a/prisma/models/Album.prisma
+++ b/prisma/models/Album.prisma
@@ -1,7 +1,8 @@
 model Album {
-    id     Int     @id @default(autoincrement())
-    name   String
-    tracks Track[]
+    id       Int     @id @default(autoincrement())
+    name     String
+    safeName String
+    tracks   Track[]
 
     @@map("albums")
 }

--- a/prisma/models/Artist.prisma
+++ b/prisma/models/Artist.prisma
@@ -1,6 +1,7 @@
 model Artist {
     id           Int             @id @default(autoincrement())
     name         String
+    safeName     String
     metadata     ArtistMetadata?
     availability Availability
     rights       Right[]

--- a/prisma/models/MusicLabel.prisma
+++ b/prisma/models/MusicLabel.prisma
@@ -1,6 +1,7 @@
 model MusicLabel {
     id           Int          @id @default(autoincrement())
     name         String
+    safeName     String
     availability Availability
     artists      Artist[]
 

--- a/src/structures/album.ts
+++ b/src/structures/album.ts
@@ -1,7 +1,7 @@
 /** @module AlbumStructs Contains data structures for albums. */
 import { Prisma } from "@prisma/client"
 import { TrackCreateTemplate, trackCTToInput } from "./track"
-import { isBlankArray } from "../util/templateValidation"
+import { toSafeName, isBlankArray } from "../util/templateValidation"
 
 /** The create template for albums. */
 export type AlbumCreateTemplate = {
@@ -19,7 +19,8 @@ export type AlbumCreateTemplate = {
 export function albumCTToInput(albumCT: AlbumCreateTemplate): Prisma.AlbumCreateWithoutArtistMetadataInput {
     return {
         name: albumCT.name,
-        tracks: 
+        safeName: toSafeName(albumCT.name),
+        tracks:
             albumCT.tracks !== undefined && !isBlankArray(albumCT.tracks)
             ? { create: albumCT.tracks.map((trackCT) => trackCTToInput(trackCT)) }
             : undefined

--- a/src/structures/artist.ts
+++ b/src/structures/artist.ts
@@ -3,7 +3,7 @@ import { Prisma, Artist, Availability } from "@prisma/client";
 import { Database } from "../../prisma";
 import { ArtistMetadataCreateTemplate, artistMetadataCTToInput } from "./artistMetadata";
 import { RightCreateTemplate, rightCTToInput } from "./right";
-import { toSafeName, toSafeNameSafe, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
+import { toSafeName, ensureSafeName, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
 
 /** The create template for artists. */
 export type ArtistCreateTemplate = {
@@ -56,7 +56,7 @@ export function artistUTToInput(artistUT: ArtistUpdateTemplate): Prisma.ArtistUp
     let ensuredName = ensureNotBlankString(artistUT.name)
     return {
         name: ensuredName,
-        safeName: toSafeNameSafe(ensuredName),
+        safeName: ensureSafeName(ensuredName),
         metadata:
             artistUT.metadata
             ? { create: artistMetadataCTToInput(artistUT.metadata) }

--- a/src/structures/artist.ts
+++ b/src/structures/artist.ts
@@ -3,7 +3,7 @@ import { Prisma, Artist, Availability } from "@prisma/client";
 import { Database } from "../../prisma";
 import { ArtistMetadataCreateTemplate, artistMetadataCTToInput } from "./artistMetadata";
 import { RightCreateTemplate, rightCTToInput } from "./right";
-import { isBlankArray, ensureNotBlankString } from "../util/templateValidation";
+import { toSafeName, toSafeNameSafe, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
 
 /** The create template for artists. */
 export type ArtistCreateTemplate = {
@@ -23,6 +23,7 @@ export type ArtistCreateTemplate = {
 export function artistCTToInput(artistCT: ArtistCreateTemplate): Prisma.ArtistCreateWithoutMusicLabelInput {
     return {
         name: artistCT.name,
+        safeName: toSafeName(artistCT.name),
         metadata:
             artistCT.metadata
             ? { create: artistMetadataCTToInput(artistCT.metadata) }
@@ -52,8 +53,10 @@ export type ArtistUpdateTemplate = {
  * Note that this doesn't include relations to the "upper level" (eg, no `artistId` included in the artist's metadata).
  */
 export function artistUTToInput(artistUT: ArtistUpdateTemplate): Prisma.ArtistUpdateWithoutMusicLabelInput {
+    let ensuredName = ensureNotBlankString(artistUT.name)
     return {
-        name: ensureNotBlankString(artistUT.name),
+        name: ensuredName,
+        safeName: toSafeNameSafe(ensuredName),
         metadata:
             artistUT.metadata
             ? { create: artistMetadataCTToInput(artistUT.metadata) }

--- a/src/structures/musicLabel.ts
+++ b/src/structures/musicLabel.ts
@@ -2,7 +2,7 @@
 import { Prisma, Availability } from "@prisma/client"
 import { Database } from "../../prisma";
 import { ArtistCreateTemplate, artistCTToInput } from "./artist";
-import { toSafeName, toSafeNameSafe, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
+import { toSafeName, ensureSafeName, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
 
 /** The create template for music labels. */
 export type MusicLabelCreateTemplate = {
@@ -40,7 +40,7 @@ export function musicLabelUTToInput(musicLabelUT: MusicLabelUpdateTemplate): Pri
     let ensuredName = ensureNotBlankString(musicLabelUT.name)
     return {
         name: ensuredName,
-        safeName: toSafeNameSafe(ensuredName),
+        safeName: ensureSafeName(ensuredName),
         availability: musicLabelUT.availability,
         artists:
             musicLabelUT.artists !== undefined && !isBlankArray(musicLabelUT.artists)

--- a/src/structures/musicLabel.ts
+++ b/src/structures/musicLabel.ts
@@ -2,7 +2,7 @@
 import { Prisma, Availability } from "@prisma/client"
 import { Database } from "../../prisma";
 import { ArtistCreateTemplate, artistCTToInput } from "./artist";
-import { isBlankArray, ensureNotBlankString } from "../util/templateValidation";
+import { toSafeName, toSafeNameSafe, isBlankArray, ensureNotBlankString } from "../util/templateValidation";
 
 /** The create template for music labels. */
 export type MusicLabelCreateTemplate = {
@@ -21,6 +21,7 @@ export type MusicLabelCreateTemplate = {
 export function musicLabelCTToInput(musicLabelCT: MusicLabelCreateTemplate): Prisma.MusicLabelCreateInput {
     return {
         name: musicLabelCT.name,
+        safeName: toSafeName(musicLabelCT.name),
         availability: musicLabelCT.availability,
         artists:
             musicLabelCT.artists !== undefined && !isBlankArray(musicLabelCT.artists)
@@ -36,8 +37,10 @@ export type MusicLabelUpdateTemplate = {
 }
 
 export function musicLabelUTToInput(musicLabelUT: MusicLabelUpdateTemplate): Prisma.MusicLabelUpdateInput {
+    let ensuredName = ensureNotBlankString(musicLabelUT.name)
     return {
-        name: ensureNotBlankString(musicLabelUT.name),
+        name: ensuredName,
+        safeName: toSafeNameSafe(ensuredName),
         availability: musicLabelUT.availability,
         artists:
             musicLabelUT.artists !== undefined && !isBlankArray(musicLabelUT.artists)

--- a/src/util/templateValidation.ts
+++ b/src/util/templateValidation.ts
@@ -12,6 +12,16 @@ export function toSafeName(name: string) {
     return name.trim().replaceAll(" ", "_").toLowerCase();
 }
 
+/**
+ * Like {@link toSafeName}, but returns `undefined` if {@link name} is `undefined`.
+ * 
+ * @param name The name to convert.
+ * @returns The safe name if {@link name} is a string, otherwise `undefined`.
+ */
+export function toSafeNameSafe(name: string | undefined) {
+    return name !== undefined ? toSafeName(name) : undefined
+}
+
 
 /**
  * Returns `true` if the string is not `undefined` and not `""`, otherwise `false`.

--- a/src/util/templateValidation.ts
+++ b/src/util/templateValidation.ts
@@ -18,7 +18,7 @@ export function toSafeName(name: string) {
  * @param name The name to convert.
  * @returns The safe name if {@link name} is a string, otherwise `undefined`.
  */
-export function toSafeNameSafe(name: string | undefined) {
+export function ensureSafeName(name: string | undefined) {
     return name !== undefined ? toSafeName(name) : undefined
 }
 


### PR DESCRIPTION
This PR includes updates to the schema which includes `safeName`s for `album`s, `artist`s, and `musicLabel`s.
`CTToInput` and `UTToInput` functions are also updated to use the new schema.